### PR TITLE
Mosql timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.1.2
+  - 2.2.3
 services:
   - mongodb
   - postgresql

--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -107,6 +107,11 @@ module MoSQL
         opts.on("--oplog-filter [filter]", "An additional JSON filter for the oplog query") do |filter|
           @options[:oplog_filter] = JSON.parse(filter)
         end
+
+        #Configurable timeout field to override the default of 20 seconds
+        opts.on("--socket-timeout", "Set the timeout for reads from MongoDB") do |timeout|
+          @options[:op_timeout] = timeout
+        end
       end
 
       optparse.parse!(@args)
@@ -121,7 +126,7 @@ module MoSQL
     end
 
     def connect_mongo
-      @mongo = Mongo::MongoClient.from_uri(options[:mongo])
+      @mongo = Mongo::MongoClient.from_uri(options[:mongo], op_timeout: options[:op_timeout])
       config = @mongo['admin'].command(:ismaster => 1)
       if !config['setName'] && !options[:skip_tail]
         log.warn("`#{options[:mongo]}' is not a replset.")

--- a/lib/mosql/cli.rb
+++ b/lib/mosql/cli.rb
@@ -109,8 +109,8 @@ module MoSQL
         end
 
         #Configurable timeout field to override the default of 20 seconds
-        opts.on("--socket-timeout", "Set the timeout for reads from MongoDB") do |timeout|
-          @options[:op_timeout] = timeout
+        opts.on("--socket-timeout [timeout]", "Set the timeout for reads from MongoDB") do |timeout|
+          @options[:op_timeout] = timeout.to_i
         end
       end
 

--- a/lib/mosql/sql.rb
+++ b/lib/mosql/sql.rb
@@ -19,6 +19,7 @@ module MoSQL
                                end
                                conn.execute("SET search_path TO \"#{pgschema}\"")
                              end
+                               conn.execute('SET statement_timeout = 180000')
                            end)
     end
 

--- a/lib/mosql/streamer.rb
+++ b/lib/mosql/streamer.rb
@@ -73,7 +73,7 @@ module MoSQL
           raise if e.kind_of?(Mongo::OperationFailure) && [11000, 11001].include?(e.error_code)
           # Cursor timeout
           raise if e.kind_of?(Mongo::OperationFailure) && e.message =~ /^Query response returned CURSOR_NOT_FOUND/
-          delay = 0.5 * (1.5 ** try)
+          delay = 0.5 * (2 ** try)
           log.warn("Mongo exception: #{e}, sleeping #{delay}s...")
           sleep(delay)
         end

--- a/mosql.gemspec
+++ b/mosql.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "mongoriver", "0.4"
 
-  gem.add_runtime_dependency "mongo", "~> 1.10"
-  gem.add_runtime_dependency "bson", "~> 1.10"
-  gem.add_runtime_dependency "bson_ext", "~> 1.10"
+  gem.add_runtime_dependency "mongo", "~> 1.0"
+  gem.add_runtime_dependency "bson", "~> 1.0"
+  gem.add_runtime_dependency "bson_ext", "~> 1.0"
 
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "mocha"


### PR DESCRIPTION
-Added CLI option to set socket timeout in Mongo
-Increased time delay between Mongo Retries.
-Wrapped oplog updates in a retry block with max 3 retries and 30 min total delay

@kylev 
